### PR TITLE
DRF에서 CustomJWTAuthentication 클래스 설정

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'auth.auth.CustomJWTAuthentication',
     ),
 }
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -57,7 +57,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'config.middleware.JWTAuthenticationMiddleware',  # 추가된 미들웨어
 ]
 
 ROOT_URLCONF = 'config.urls'


### PR DESCRIPTION
# DRF에서 CustomJWTAuthentication 클래스 설정

CustomJWTAuthentication 클래스를 DRF의 기본 인증 클래스로 설정하면, SimpleJWT의 기본 인증 클래스 대신 작성한 클래스를 사용하게 됩니다.

## 설정 방법

settings.py에서 DEFAULT_AUTHENTICATION_CLASSES를 수정합니다:

```REST_FRAMEWORK = {
    'DEFAULT_AUTHENTICATION_CLASSES': [
        'auth.auth.CustomJWTAuthentication',  # Custom Authentication 클래스 경로
    ],
}
```
## 작동 방식
- DRF는 요청을 처리할 때 DEFAULT_AUTHENTICATION_CLASSES 목록에 등록된 인증 클래스를 순서대로 호출합니다.
- 요청이 들어오면:
  - CustomJWTAuthentication.authenticate() 메서드가 호출됩니다.
  - 여기서 JWT를 검증하고 인증 정보를 반환하거나, 실패 시 예외를 발생시킵니다.

## CustomJWTAuthentication 사용 이유
- SimpleJWT는 기본적으로 AccessToken을 사용해 토큰을 처리하지만, CustomJWTAuthentication을 설정하면 원하는 로직(예: 경로별 인증 제외, Payload Decoding 연기 등)을 추가로 구현할 수 있습니다.

## 리뷰어 참고 사항
- “Verify Signature”는 토큰이 변조되지 않았음을 확인하는 과정으로, 서버 비밀키를 사용해 생성된 Signature를 검증합니다.
- AccessToken은 SimpleJWT의 검증 로직을 활용하면서도 토큰의 Decoding을 강제하지 않아, 서명 검증만 수행하고 싶을 때 적합합니다.
- CustomJWTAuthentication을 DRF 기본 인증 클래스로 설정하면 작성한 인증 로직이 DRF 전역에 적용됩니다. SimpleJWT 기본 인증 클래스를 대체하게 되며, 이를 통해 더욱 세밀한 검증 로직을 구현할 수 있습니다.